### PR TITLE
Patch for larwirecell 10.00.02.

### DIFF
--- a/packages/larwirecell/package.py
+++ b/packages/larwirecell/package.py
@@ -21,6 +21,8 @@ class Larwirecell(CMakePackage, FnalGithubPackage):
 
     cxxstd_variant("17", "20", default="17")
 
+    patch('v10.00.02.patch', when="@10.00.02")
+    
     depends_on("cetmodules", type="build")
 
     depends_on("art")

--- a/packages/larwirecell/v10.00.02.patch
+++ b/packages/larwirecell/v10.00.02.patch
@@ -7,7 +7,7 @@ index 124056e..e0fced4 100644
  void OpFlashSource::visit(art::Event& event)
  {
 -  log->debug("OpFlashSource::visit {}", m_inputTag);
-+  //log->debug("OpFlashSource::visit {}", m_inputTag);
++  log->debug("OpFlashSource::visit {}", m_inputTag.encode());
    art::Handle<std::vector<recob::OpFlash>> opflashes;
    event.getByLabel(m_inputTag, opflashes);
    if (!opflashes.isValid()) {

--- a/packages/larwirecell/v10.00.02.patch
+++ b/packages/larwirecell/v10.00.02.patch
@@ -1,0 +1,20 @@
+diff --git a/larwirecell/Components/OpFlashSource.cxx b/larwirecell/Components/OpFlashSource.cxx
+index 124056e..e0fced4 100644
+--- a/larwirecell/Components/OpFlashSource.cxx
++++ b/larwirecell/Components/OpFlashSource.cxx
+@@ -51,7 +51,7 @@ void OpFlashSource::configure(const WireCell::Configuration& cfg)
+ 
+ void OpFlashSource::visit(art::Event& event)
+ {
+-  log->debug("OpFlashSource::visit {}", m_inputTag);
++  //log->debug("OpFlashSource::visit {}", m_inputTag);
+   art::Handle<std::vector<recob::OpFlash>> opflashes;
+   event.getByLabel(m_inputTag, opflashes);
+   if (!opflashes.isValid()) {
+@@ -96,4 +96,4 @@ bool OpFlashSource::operator()(WireCell::ITensorSet::pointer& tensorset)
+   tensorset = m_tensorsets.front();
+   m_tensorsets.pop_front();
+   return true;
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
Otherwise got errors:
<pre>  >> 635    /exp/dune/data/users/tjyang/spack/opt/spack/linux-almalinux9-zen3/gcc-11.5.0/fmt-11.0.2-z7frqkryovdgo32hu5ecwwyeexacfbzh/include/fmt/base.h:1641:63: error: 
            'fmt::v11::detail::type_is_unformattable_for<art::InputTag, char> _' has incomplete type
     636     1641 |     type_is_unformattable_for<T, typename Context::char_type> _;
     637          |                                                               ^
  >> 638    /exp/dune/data/users/tjyang/spack/opt/spack/linux-almalinux9-zen3/gcc-11.5.0/fmt-11.0.2-z7frqkryovdgo32hu5ecwwyeexacfbzh/include/fmt/base.h:1644:7: error: s
            tatic assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
     639     1644 |       formattable,
     640          |       ^~~~~~~~~~~
     641    /exp/dune/data/users/tjyang/spack/opt/spack/linux-almalinux9-zen3/gcc-11.5.0/fmt-11.0.2-z7frqkryovdgo32hu5ecwwyeexacfbzh/include/fmt/base.h:1644:7: note: 'f
            ormattable' evaluates to false
  >> 642    make[2]: *** [larwirecell/Components/CMakeFiles/WireCellLarsoft.dir/build.make:194: larwirecell/Components/CMakeFiles/WireCellLarsoft.dir/OpFlashSource.cxx.
            o] Error 1
</pre>