### PR TITLE
Fix torch-scatter `cmake_prefix_paths` property

### DIFF
--- a/packages/torch-scatter/package.py
+++ b/packages/torch-scatter/package.py
@@ -52,6 +52,4 @@ class TorchScatter(CMakePackage):
 
     @property
     def cmake_prefix_paths(self):
-        return "{0}".format(self.spec["py-torch"].package.cmake_prefix_paths[0])
-
-
+        return [self.spec["py-torch"].package.cmake_prefix_paths[0]]


### PR DESCRIPTION
The `cmake_prefix_paths` property needs to return a list whose entries are paths.