### PR TITLE
larrecodnn patch would make tensorflow required when finding via cmak…

### DIFF
--- a/spack_repo/larsoft/packages/larrecodnn/package.py
+++ b/spack_repo/larsoft/packages/larrecodnn/package.py
@@ -7,6 +7,32 @@ from spack import *
 from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.fnal_art.packages.fnal_github_package.package import *
+def patch_scatter():
+    #Take TorchScatter out of all link lists
+    filter_file("TorchScatter::TorchScatter",
+                "#TorchScatter::TorchScatter",
+                "larrecodnn/NuGraph/CMakeLists.txt",
+                )
+    # but put it back for NuGraphInference
+    filter_file("IMPL_TARGET_VAR NuGraphInference_module",
+                "TorchScatter::TorchScatter\nIMPL_TARGET_VAR NuGraphInference_module",
+                "larrecodnn/NuGraph/CMakeLists.txt",
+                )
+
+def patch_tensorflow():
+    filter_file("LANGUAGES CXX", "LANGUAGES CXX C", "CMakeLists.txt")
+    filter_file("find_package\(TensorFlow 2.6.0 QUIET EXPORT\)",
+            'list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".so.2")\nfind_package(TensorFlow 2.6.0 REQUIRED EXPORT)',
+            "CMakeLists.txt"
+            )
+    filter_file('#include "tensorflow/cc/saved_model/tag_constants.h"',
+                '#include "tensorflow/cc/saved_model/bundle_v2.h"\n#include "tensorflow/cc/saved_model/constants.h"\n#include "tensorflow/cc/saved_model/loader.h"',
+                "larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc",
+                )
+    filter_file("{tensorflow::kSavedModelTagServe},",
+                "{},",
+                "larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc",
+                )
 
 
 class Larrecodnn(CMakePackage, FnalGithubPackage):
@@ -79,31 +105,14 @@ class Larrecodnn(CMakePackage, FnalGithubPackage):
     depends_on("triton")
     depends_on("zlib")
 
+    @when("+tensorflow")
     def patch(self):
-        filter_file("LANGUAGES CXX", "LANGUAGES CXX C", "CMakeLists.txt")
-        filter_file("find_package\(TensorFlow 2.6.0 QUIET EXPORT\)",
-                'list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".so.2")\nfind_package(TensorFlow 2.6.0 REQUIRED EXPORT)',
-                "CMakeLists.txt"
-                )
-        filter_file('#include "tensorflow/cc/saved_model/tag_constants.h"',
-                    '#include "tensorflow/cc/saved_model/bundle_v2.h"\n#include "tensorflow/cc/saved_model/constants.h"\n#include "tensorflow/cc/saved_model/loader.h"',
-                    "larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc",
-                    )
-        filter_file("{tensorflow::kSavedModelTagServe},",
-                    "{},",
-                    "larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc",
-                    )
-        #Take TorchScatter out of all link lists
-        filter_file("TorchScatter::TorchScatter",
-                    "#TorchScatter::TorchScatter",
-                    "larrecodnn/NuGraph/CMakeLists.txt",
-                    )
-        # but put it back for NuGraphInference
-        filter_file("IMPL_TARGET_VAR NuGraphInference_module",
-                    "TorchScatter::TorchScatter\nIMPL_TARGET_VAR NuGraphInference_module",
-                    "larrecodnn/NuGraph/CMakeLists.txt",
-                    )
+      patch_tensorflow()
+      patch_scatter()
 
+    @when("~tensorflow")
+    def patch(self):
+      patch_scatter()
 
     @cmake_preset
     def cmake_args(self):


### PR DESCRIPTION
…e. Turned that off when spec is '~tensorflow'


I couldn't get '+tensorflow' to build but this does build with '~tensorflow'
<pre>
calcuttj@wcgpu0:/nfs/data/1/calcuttj/spack-testing$ spack -kL install 
HEAD is now at 0a073fe Put back original name for backwards compatibility
HEAD is now at 0f3de95 Merge pull request #1 from gartung/develop
HEAD is now at 0a073fe Put back original name for backwards compatibility
HEAD is now at 0f3de95 Merge pull request #1 from gartung/develop
==> Warning: You asked for --insecure. Will NOT check SSL certificates.
HEAD is now at 0a073fe Put back original name for backwards compatibility
HEAD is now at 0f3de95 Merge pull request #1 from gartung/develop
HEAD is now at 0a073fe Put back original name for backwards compatibility
HEAD is now at 0f3de95 Merge pull request #1 from gartung/develop
 ==> Error: failed to concretize `larsoft+tensorflow ^artg4tk@12.00.03 ^wire-cell-toolkit+cuda+hdf+torch` for the following reasons:
     1. py-tensorflow: '%gcc@:11' conflicts with '@2.17:'
     2. py-tensorflow: '%gcc@:11' conflicts with '@2.17:'
        required because conflict constraint @2.17: 
          required because larrecodnn depends on py-tensorflow when +tensorflow 
            required because larsoft depends on larrecodnn+tensorflow when +tensorflow 
              required because larsoft+tensorflow ^artg4tk@12.00.03 ^wire-cell-toolkit+cuda+hdf+torch requested explicitly 
          required because larsimdnn depends on py-tensorflow when +tensorflow 
            required because larsoft depends on larsimdnn+tensorflow when +tensorflow 
        required because conflict is triggered when %gcc@:11 
          required because gcc-runtime depends on gcc 
          required because larrecodnn depends on py-tensorflow when +tensorflow 
            required because larsoft depends on larrecodnn+tensorflow when +tensorflow 
              required because larsoft+tensorflow ^artg4tk@12.00.03 ^wire-cell-toolkit+cuda+hdf+torch requested explicitly 
          required because larsimdnn depends on py-tensorflow when +tensorflow 
            required because larsoft depends on larsimdnn+tensorflow when +tensorflow 

</pre>